### PR TITLE
Fix session timeout and implement question answer persistence

### DIFF
--- a/src/app/components/answer-option/answer-option.component.html
+++ b/src/app/components/answer-option/answer-option.component.html
@@ -1,6 +1,6 @@
 <div class="option-wrapper" (click)="clickAnswer()"
      [ngClass]="{'correct-answer': (selectedAnswer && selectedAnswer.length > 0 || testFinished) && isCorrect, 'wrong-answer': (selectedAnswer && selectedAnswer.length > 0 || testFinished) && !isCorrect}">
-  <input [name]="name" [readOnly]="(selectedAnswer && selectedAnswer.length > 0 || testFinished)" type="radio" [id]="id" [disabled]="disabled">
+  <input [name]="name" [readOnly]="(selectedAnswer && selectedAnswer.length > 0 || testFinished)" type="radio" [id]="id" [disabled]="disabled" [checked]="selectedAnswer === id">
   <label [for]="id" class="answer" [ngClass]="{'disabled': (selectedAnswer && selectedAnswer.length > 0) || disabled}">
     {{answerOption}}
   </label>

--- a/src/app/components/progress-toggle/progress-toggle.component.ts
+++ b/src/app/components/progress-toggle/progress-toggle.component.ts
@@ -94,7 +94,7 @@ export class ProgressToggleComponent implements OnInit, OnDestroy {
    */
   private updateVisibility(): void {
     const currentUrl = this.router.url;
-    const hiddenRoutes = ['/addQuestion', '/test', '/results'];
+    const hiddenRoutes = ['/login', '/addQuestion', '/test', '/results'];
     
     // Hide if user is not authenticated
     if (!this.currentUserId) {
@@ -102,7 +102,7 @@ export class ProgressToggleComponent implements OnInit, OnDestroy {
       return;
     }
     
-    // Hide in admin areas, test exams, and data analysis
+    // Hide in admin areas, test exams, data analysis, and login page
     this.isVisible = !hiddenRoutes.some(route => currentUrl.includes(route));
   }
 

--- a/src/app/components/question-card/question-card.component.ts
+++ b/src/app/components/question-card/question-card.component.ts
@@ -42,6 +42,11 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
     this.wrongAnswerClicked = !isCorrect;
     this.selectedAnswer = id;
     
+    // Save the answer for persistence across reloads
+    if (this.questionItem.id) {
+      this.testService.saveQuestionAnswer(this.questionItem.id, id);
+    }
+    
     if (this.progressService.isTrackingEnabled && this.firstClick) {
       // Record section-specific answer with timestamp
       this.progressService.recordQuestionAnswer(
@@ -60,6 +65,18 @@ export class QuestionCardComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.resetComponentState();
       });
+    
+    // Check if this question has a saved answer
+    if (this.questionItem.id) {
+      const savedAnswer = this.testService.getSavedAnswer(this.questionItem.id);
+      if (savedAnswer) {
+        // Restore the saved answer state
+        this.clicked = true;
+        this.selectedAnswer = savedAnswer;
+        this.wrongAnswerClicked = savedAnswer !== this.questionItem.correctAnswer;
+        this.firstClick = false;
+      }
+    }
   }
 
   ngOnDestroy(): void {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,15 +1,16 @@
-import {Injectable} from '@angular/core';
+import {Injectable, OnDestroy} from '@angular/core';
 import {Router} from "@angular/router";
 import {BehaviorSubject, from, Subject} from "rxjs";
 import {
   Auth,
-  browserSessionPersistence,
+  browserLocalPersistence,
   GoogleAuthProvider,
   setPersistence,
   signInWithPopup,
   signOut,
   User,
-  AuthError
+  AuthError,
+  onAuthStateChanged
 } from "firebase/auth";
 import {Auth as AngularFireAuth} from '@angular/fire/auth';
 import {CookieService} from "ngx-cookie-service";
@@ -18,11 +19,18 @@ import {UserInfo} from "../models/User.model";
 @Injectable({
               providedIn: 'root'
             })
-export class AuthService {
+export class AuthService implements OnDestroy {
   loginChanged = new BehaviorSubject<UserInfo | null>(this.getInitialUserState())
   errorStatusChanged = new Subject<AuthError>()
+  
+  private sessionCheckInterval: any = null;
+  private authStateUnsubscribe: any = null;
+  private activityMonitorInterval: any = null;
+  private lastActivityTime: number = Date.now();
 
   constructor(private auth: AngularFireAuth, private router: Router, private cookieService: CookieService) {
+    this.initializeAuthStateMonitor();
+    this.setupActivityMonitoring();
   }
 
   private getInitialUserState(): UserInfo | null {
@@ -30,7 +38,6 @@ export class AuthService {
       const userData = this.cookieService.get('userData');
       return userData ? JSON.parse(userData) : null;
     } catch (error) {
-      console.error('Error parsing user data from cookie:', error);
       this.cookieService.delete('userData');
       return null;
     }
@@ -39,14 +46,27 @@ export class AuthService {
   handleLogin() {
     const user = this.auth.currentUser
     if (user !== null) {
-      // cookie
+      // cookie - Set to 8 hours for a full school/work day
       const expirationTime = (new Date())
-      expirationTime.setHours(expirationTime.getHours() + 1)
+      expirationTime.setHours(expirationTime.getHours() + 8)
       this.cookieService.set('userData', JSON.stringify(user), {expires: expirationTime})
+      
+      // Store expiration time for session monitoring
+      localStorage.setItem('sessionExpiration', expirationTime.getTime().toString())
 
       this.loginChanged.next(user)
+      
+      // Check if we should return to a previous URL after re-authentication
+      const returnUrl = localStorage.getItem('returnUrl');
+      if (returnUrl) {
+        localStorage.removeItem('returnUrl');
+        this.router.navigate([returnUrl]).then();
+      } else {
+        this.router.navigate(['/home']).then();
+      }
+    } else {
+      this.router.navigate(['/home']).then()
     }
-    this.router.navigate(['/home']).then()
   }
 
   handleError(error: AuthError) {
@@ -54,7 +74,7 @@ export class AuthService {
   }
 
   googleLogin() {
-    setPersistence(this.auth, browserSessionPersistence).then(() => {
+    setPersistence(this.auth, browserLocalPersistence).then(() => {
       const provider = new GoogleAuthProvider();
       const googleLoginObservable = from(signInWithPopup(this.auth, provider))
       googleLoginObservable
@@ -72,5 +92,131 @@ export class AuthService {
     this.loginChanged.next(null)
     this.cookieService.delete('userData')
     this.cookieService.delete('adminState')
+    this.clearSessionMonitoring();
+  }
+
+  /**
+   * Initialize Firebase auth state monitoring to handle session expiration
+   */
+  private initializeAuthStateMonitor(): void {
+    this.authStateUnsubscribe = onAuthStateChanged(this.auth, (user) => {
+      if (user) {
+        // User is signed in, update login state if needed
+        const currentUser = this.loginChanged.value;
+        if (!currentUser || currentUser.uid !== user.uid) {
+          // Only re-establish session if we're on the login page
+          if (this.router.url === '/login') {
+            this.handleLogin();
+          }
+        }
+        this.startSessionMonitoring();
+      } else {
+        // User is signed out
+        if (this.loginChanged.value) {
+          // Session expired - save current state before redirecting
+          this.handleSessionExpired();
+        }
+      }
+    });
+  }
+
+  /**
+   * Start monitoring session expiration
+   */
+  private startSessionMonitoring(): void {
+    this.clearSessionMonitoring();
+    
+    // Check session status every 5 minutes
+    this.sessionCheckInterval = setInterval(() => {
+      const cookieExpiration = this.getCookieExpiration();
+      if (cookieExpiration) {
+        const hoursRemaining = (cookieExpiration - Date.now()) / (1000 * 60 * 60);
+        
+        // Auto-refresh if less than 1 hour remaining and user is active
+        if (hoursRemaining <= 1 && hoursRemaining > 0) {
+          const timeSinceLastActivity = Date.now() - this.lastActivityTime;
+          const fifteenMinutes = 15 * 60 * 1000;
+          
+          // Only refresh if user has been active in the last 15 minutes
+          if (timeSinceLastActivity < fifteenMinutes) {
+            this.refreshSession();
+          }
+        }
+      }
+    }, 5 * 60 * 1000); // Check every 5 minutes
+  }
+
+  /**
+   * Clear session monitoring
+   */
+  private clearSessionMonitoring(): void {
+    if (this.sessionCheckInterval) {
+      clearInterval(this.sessionCheckInterval);
+      this.sessionCheckInterval = null;
+    }
+  }
+
+  /**
+   * Get cookie expiration time
+   */
+  private getCookieExpiration(): number | null {
+    // Since we can't directly get cookie expiration, we'll store it separately
+    const expirationStr = localStorage.getItem('sessionExpiration');
+    return expirationStr ? parseInt(expirationStr, 10) : null;
+  }
+
+  /**
+   * Refresh the session by extending the cookie
+   */
+  private refreshSession(): void {
+    const user = this.auth.currentUser;
+    if (user) {
+      const expirationTime = new Date();
+      expirationTime.setHours(expirationTime.getHours() + 8); // Extend for another 8 hours
+      this.cookieService.set('userData', JSON.stringify(user), {expires: expirationTime});
+      localStorage.setItem('sessionExpiration', expirationTime.getTime().toString());
+    }
+  }
+
+  /**
+   * Handle session expiration
+   */
+  private handleSessionExpired(): void {
+    // Save current test/quiz state before redirecting
+    const currentUrl = this.router.url;
+    if (currentUrl.includes('/home') || currentUrl.includes('/test')) {
+      // Store the current URL to return to after re-authentication
+      localStorage.setItem('returnUrl', currentUrl);
+      
+      // TODO: Save current test state to localStorage
+      // This would require coordination with TestService
+    }
+    
+    this.loginChanged.next(null);
+    this.cookieService.delete('userData');
+    this.cookieService.delete('adminState');
+    this.router.navigate(['/login']);
+  }
+
+  /**
+   * Clean up auth state monitor on service destruction
+   */
+  /**
+   * Setup activity monitoring to track user interactions
+   */
+  private setupActivityMonitoring(): void {
+    // Update activity time on user interactions
+    ['click', 'keypress', 'mousemove', 'scroll', 'touchstart'].forEach(event => {
+      document.addEventListener(event, () => {
+        this.lastActivityTime = Date.now();
+      });
+    });
+  }
+
+  ngOnDestroy(): void {
+    if (this.authStateUnsubscribe) {
+      this.authStateUnsubscribe();
+    }
+    this.clearSessionMonitoring();
   }
 }

--- a/src/app/services/test.service.spec.ts
+++ b/src/app/services/test.service.spec.ts
@@ -1,0 +1,278 @@
+import { TestBed } from '@angular/core/testing';
+import { TestService } from './test.service';
+import { QUESTIONWEIGHTS } from '../views/test/constants';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('TestService', () => {
+  let service: TestService;
+  
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(TestService);
+    // Clear localStorage before each test
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    localStorage.clear();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialize with default state', () => {
+    expect(service.correctAnswers.total.blank).toBe(100);
+    expect(service.correctAnswers.total.correct).toBe(0);
+    expect(service.correctAnswers.total.incorrect).toBe(0);
+  });
+
+  it('should update counts when answer is clicked', () => {
+    const mockQuestion = {
+      id: 'q1',
+      question: 'Test question',
+      options: ['A', 'B', 'C', 'D'],
+      correctAnswer: 'A',
+      mainSection: 'administrativo'
+    };
+
+    // First click - correct answer
+    service.addClickedAnswer(mockQuestion, 'A', true, false);
+    
+    expect(service.correctAnswers.total.correct).toBe(1);
+    expect(service.correctAnswers.total.blank).toBe(99);
+    expect(service.correctAnswers.administrativo.correct).toBe(1);
+  });
+
+  it('should reset all answers', () => {
+    // Add some answers first
+    const mockQuestion = {
+      id: 'q1',
+      question: 'Test question',
+      options: ['A', 'B', 'C', 'D'],
+      correctAnswer: 'A',
+      mainSection: 'administrativo'
+    };
+    
+    service.addClickedAnswer(mockQuestion, 'B', true, false);
+    service.saveQuestionAnswer('q1', 'B');
+    
+    // Reset
+    service.resetAllAnswers();
+    
+    expect(service.correctAnswers.total.blank).toBe(100);
+    expect(service.correctAnswers.total.correct).toBe(0);
+    expect(service.correctAnswers.total.incorrect).toBe(0);
+    expect(service.getSavedAnswer('q1')).toBeUndefined();
+  });
+
+  describe('State Persistence', () => {
+    it('should save state to localStorage', () => {
+      const mockQuestion = {
+        id: 'q1',
+        question: 'Test question',
+        options: ['A', 'B', 'C', 'D'],
+        correctAnswer: 'A',
+        mainSection: 'administrativo'
+      };
+      
+      service.addClickedAnswer(mockQuestion, 'A', true, false);
+      
+      const savedState = localStorage.getItem('testServiceState');
+      expect(savedState).toBeTruthy();
+      
+      const parsed = JSON.parse(savedState!);
+      expect(parsed.correctAnswers.total.correct).toBe(1);
+    });
+
+    it('should restore state from localStorage on creation', () => {
+      // Save state to localStorage
+      const stateToSave = {
+        correctAnswers: {
+          total: { blank: 98, correct: 2, incorrect: 0 },
+          'administrativo': { blank: 48, correct: 2, incorrect: 0 },
+          'medio ambiente': { blank: QUESTIONWEIGHTS['medio ambiente'], correct: 0, incorrect: 0 },
+          'costas': { blank: QUESTIONWEIGHTS['costas'], correct: 0, incorrect: 0 },
+          'aguas': { blank: QUESTIONWEIGHTS['aguas'], correct: 0, incorrect: 0 }
+        },
+        timestamp: Date.now()
+      };
+      
+      localStorage.setItem('testServiceState', JSON.stringify(stateToSave));
+      
+      // Create new service instance
+      const newService = new TestService();
+      
+      expect(newService.correctAnswers.total.correct).toBe(2);
+      expect(newService.correctAnswers.total.blank).toBe(98);
+    });
+
+    it('should not restore state older than 12 hours', () => {
+      const oldState = {
+        correctAnswers: {
+          total: { blank: 98, correct: 2, incorrect: 0 },
+          'administrativo': { blank: 48, correct: 2, incorrect: 0 },
+          'medio ambiente': { blank: QUESTIONWEIGHTS['medio ambiente'], correct: 0, incorrect: 0 },
+          'costas': { blank: QUESTIONWEIGHTS['costas'], correct: 0, incorrect: 0 },
+          'aguas': { blank: QUESTIONWEIGHTS['aguas'], correct: 0, incorrect: 0 }
+        },
+        timestamp: Date.now() - (13 * 60 * 60 * 1000) // 13 hours ago
+      };
+      
+      localStorage.setItem('testServiceState', JSON.stringify(oldState));
+      
+      const newService = new TestService();
+      
+      // Should have default state, not the old saved state
+      expect(newService.correctAnswers.total.correct).toBe(0);
+      expect(newService.correctAnswers.total.blank).toBe(100);
+    });
+  });
+
+  describe('Question Answer Persistence', () => {
+    it('should save question answers', () => {
+      service.saveQuestionAnswer('q1', 'A');
+      service.saveQuestionAnswer('q2', 'B');
+      
+      expect(service.getSavedAnswer('q1')).toBe('A');
+      expect(service.getSavedAnswer('q2')).toBe('B');
+    });
+
+    it('should persist question answers to localStorage', () => {
+      service.saveQuestionAnswer('q1', 'A');
+      
+      const saved = localStorage.getItem('answeredQuestions');
+      expect(saved).toBeTruthy();
+      
+      const parsed = JSON.parse(saved!);
+      expect(parsed.questions).toContainEqual(['q1', 'A']);
+    });
+
+    it('should restore question answers from localStorage', () => {
+      const answersToSave = {
+        questions: [['q1', 'A'], ['q2', 'B']],
+        timestamp: Date.now()
+      };
+      
+      localStorage.setItem('answeredQuestions', JSON.stringify(answersToSave));
+      
+      const newService = new TestService();
+      
+      expect(newService.getSavedAnswer('q1')).toBe('A');
+      expect(newService.getSavedAnswer('q2')).toBe('B');
+    });
+
+    it('should clear old question answers after 12 hours', () => {
+      const oldAnswers = {
+        questions: [['q1', 'A'], ['q2', 'B']],
+        timestamp: Date.now() - (13 * 60 * 60 * 1000) // 13 hours ago
+      };
+      
+      localStorage.setItem('answeredQuestions', JSON.stringify(oldAnswers));
+      
+      const newService = new TestService();
+      
+      expect(newService.getSavedAnswer('q1')).toBeUndefined();
+      expect(newService.getSavedAnswer('q2')).toBeUndefined();
+    });
+
+    it('should check if question has been answered', () => {
+      service.saveQuestionAnswer('q1', 'A');
+      
+      expect(service.hasAnsweredQuestion('q1')).toBe(true);
+      expect(service.hasAnsweredQuestion('q2')).toBe(false);
+    });
+
+    it('should clear answered questions on reset', () => {
+      service.saveQuestionAnswer('q1', 'A');
+      service.saveQuestionAnswer('q2', 'B');
+      
+      service.resetAllAnswers();
+      
+      expect(service.getSavedAnswer('q1')).toBeUndefined();
+      expect(service.getSavedAnswer('q2')).toBeUndefined();
+      expect(localStorage.getItem('answeredQuestions')).toBeNull();
+    });
+  });
+
+  describe('Navigation and Status', () => {
+    it('should emit test started status', () => {
+      return new Promise<void>((resolve) => {
+        service.testStatus.subscribe(status => {
+          expect(status).toBe('started');
+          resolve();
+        });
+        
+        service.handleTestStart();
+      });
+    });
+
+    it('should emit test ended status', () => {
+      return new Promise<void>((resolve) => {
+        service.testStatus.subscribe(status => {
+          expect(status).toBe('ended');
+          resolve();
+        });
+        
+        service.handleTestEnd();
+      });
+    });
+
+    it('should emit reset event', () => {
+      return new Promise<void>((resolve) => {
+        service.resetAnswers.subscribe(() => {
+          expect(true).toBe(true);
+          resolve();
+        });
+        
+        service.resetAllAnswers();
+      });
+    });
+  });
+
+  describe('Answer Change Handling', () => {
+    const mockQuestion = {
+      id: 'q1',
+      question: 'Test question',
+      options: ['A', 'B', 'C', 'D'],
+      correctAnswer: 'A',
+      mainSection: 'administrativo'
+    };
+
+    it('should handle changing from wrong to correct answer', () => {
+      // First click - wrong answer
+      service.addClickedAnswer(mockQuestion, 'B', true, false);
+      expect(service.correctAnswers.total.incorrect).toBe(1);
+      expect(service.correctAnswers.total.correct).toBe(0);
+      
+      // Change to correct answer
+      service.addClickedAnswer(mockQuestion, 'A', false, true);
+      expect(service.correctAnswers.total.incorrect).toBe(0);
+      expect(service.correctAnswers.total.correct).toBe(1);
+    });
+
+    it('should handle changing from correct to wrong answer', () => {
+      // First click - correct answer
+      service.addClickedAnswer(mockQuestion, 'A', true, false);
+      expect(service.correctAnswers.total.correct).toBe(1);
+      expect(service.correctAnswers.total.incorrect).toBe(0);
+      
+      // Change to wrong answer
+      service.addClickedAnswer(mockQuestion, 'B', false, false);
+      expect(service.correctAnswers.total.correct).toBe(0);
+      expect(service.correctAnswers.total.incorrect).toBe(1);
+    });
+
+    it('should not change counts when selecting same wrong answer again', () => {
+      // First click - wrong answer
+      service.addClickedAnswer(mockQuestion, 'B', true, false);
+      
+      // Click same wrong answer again
+      service.addClickedAnswer(mockQuestion, 'B', false, true);
+      
+      expect(service.correctAnswers.total.incorrect).toBe(1);
+      expect(service.correctAnswers.total.correct).toBe(0);
+    });
+  });
+});

--- a/src/app/services/test.service.ts
+++ b/src/app/services/test.service.ts
@@ -20,33 +20,48 @@ interface ClickedAnswer {
 export class TestService {
   testStatus: Subject<string> = new Subject<string>()
   resetAnswers: Subject<void> = new Subject<void>()
-  correctAnswers: { [key: string]: { blank: number, correct: number, incorrect: number } } = {
-    total: {
-      blank: 100,
-      correct: 0,
-      incorrect: 0
-    },
-    'administrativo': {
-      blank: QUESTIONWEIGHTS['administrativo'],
-      correct: 0,
-      incorrect: 0
-    },
-    'medio ambiente': {
-      blank: QUESTIONWEIGHTS['medio ambiente'],
-      correct: 0,
-      incorrect: 0
-    },
-    'costas': {
-      blank: QUESTIONWEIGHTS['costas'],
-      correct: 0,
-      incorrect: 0
-    },
-    'aguas': {
-      blank: QUESTIONWEIGHTS['aguas'],
-      correct: 0,
-      incorrect: 0
-    },
+  private readonly TEST_STATE_KEY = 'testServiceState';
+  private readonly ANSWERED_QUESTIONS_KEY = 'answeredQuestions';
+  correctAnswers: { [key: string]: { blank: number, correct: number, incorrect: number } }
+  private answeredQuestions: Map<string, string> = new Map(); // questionId -> selectedAnswer
 
+  constructor() {
+    // Initialize with default values or restore from saved state
+    this.correctAnswers = this.restoreState() || this.getDefaultState();
+    this.restoreAnsweredQuestions();
+  }
+
+  /**
+   * Get the default state for correct answers
+   */
+  private getDefaultState() {
+    return {
+      total: {
+        blank: 100,
+        correct: 0,
+        incorrect: 0
+      },
+      'administrativo': {
+        blank: QUESTIONWEIGHTS['administrativo'],
+        correct: 0,
+        incorrect: 0
+      },
+      'medio ambiente': {
+        blank: QUESTIONWEIGHTS['medio ambiente'],
+        correct: 0,
+        incorrect: 0
+      },
+      'costas': {
+        blank: QUESTIONWEIGHTS['costas'],
+        correct: 0,
+        incorrect: 0
+      },
+      'aguas': {
+        blank: QUESTIONWEIGHTS['aguas'],
+        correct: 0,
+        incorrect: 0
+      },
+    };
   }
 
 
@@ -90,6 +105,9 @@ export class TestService {
         this.correctAnswers[questionItem.mainSection].correct--;
       }
     }
+    
+    // Save state after each answer
+    this.saveState();
   }
 
   /**
@@ -111,33 +129,14 @@ export class TestService {
    * Restores original question counts from QUESTIONWEIGHTS configuration
    */
   resetAllAnswers(): void {
-    this.correctAnswers = {
-      total: {
-        blank: 100,
-        correct: 0,
-        incorrect: 0
-      },
-      'administrativo': {
-        blank: QUESTIONWEIGHTS['administrativo'],
-        correct: 0,
-        incorrect: 0
-      },
-      'medio ambiente': {
-        blank: QUESTIONWEIGHTS['medio ambiente'],
-        correct: 0,
-        incorrect: 0
-      },
-      'costas': {
-        blank: QUESTIONWEIGHTS['costas'],
-        correct: 0,
-        incorrect: 0
-      },
-      'aguas': {
-        blank: QUESTIONWEIGHTS['aguas'],
-        correct: 0,
-        incorrect: 0
-      }
-    };
+    this.correctAnswers = this.getDefaultState();
+    
+    // Clear saved state from localStorage
+    this.clearSavedState();
+    
+    // Clear answered questions
+    this.answeredQuestions.clear();
+    this.clearAnsweredQuestionsFromStorage();
     
     this.clearRadioButtons();
     this.resetAnswers.next();
@@ -160,5 +159,141 @@ export class TestService {
     radioButtons.forEach((radio: Element) => {
       (radio as HTMLInputElement).checked = false;
     });
+  }
+
+  /**
+   * Save current test state to localStorage
+   */
+  private saveState(): void {
+    try {
+      const stateToSave = {
+        correctAnswers: this.correctAnswers,
+        timestamp: Date.now()
+      };
+      localStorage.setItem(this.TEST_STATE_KEY, JSON.stringify(stateToSave));
+    } catch (error) {
+      // Error saving test state
+    }
+  }
+
+  /**
+   * Restore test state from localStorage
+   */
+  private restoreState(): { [key: string]: { blank: number, correct: number, incorrect: number } } | null {
+    try {
+      const savedState = localStorage.getItem(this.TEST_STATE_KEY);
+      if (savedState) {
+        const parsed = JSON.parse(savedState);
+        
+        // Check if saved state is not too old (12 hours)
+        const twelveHoursAgo = Date.now() - (12 * 60 * 60 * 1000);
+        if (parsed.timestamp && parsed.timestamp > twelveHoursAgo) {
+          return parsed.correctAnswers;
+        } else {
+          // Clear old state
+          this.clearSavedState();
+        }
+      }
+    } catch (error) {
+      this.clearSavedState();
+    }
+    return null;
+  }
+
+  /**
+   * Clear saved state from localStorage
+   */
+  private clearSavedState(): void {
+    try {
+      localStorage.removeItem(this.TEST_STATE_KEY);
+    } catch (error) {
+      // Error clearing saved test state
+    }
+  }
+
+  /**
+   * Check if there's a saved state available
+   */
+  hasSavedState(): boolean {
+    try {
+      const savedState = localStorage.getItem(this.TEST_STATE_KEY);
+      if (savedState) {
+        const parsed = JSON.parse(savedState);
+        const twelveHoursAgo = Date.now() - (12 * 60 * 60 * 1000);
+        return parsed.timestamp && parsed.timestamp > twelveHoursAgo;
+      }
+    } catch (error) {
+      console.error('Error checking saved state:', error);
+    }
+    return false;
+  }
+
+  /**
+   * Save a question answer for persistence
+   */
+  saveQuestionAnswer(questionId: string, selectedAnswer: string): void {
+    this.answeredQuestions.set(questionId, selectedAnswer);
+    this.saveAnsweredQuestionsToStorage();
+  }
+
+  /**
+   * Get a saved answer for a question
+   */
+  getSavedAnswer(questionId: string): string | undefined {
+    return this.answeredQuestions.get(questionId);
+  }
+
+  /**
+   * Check if a question has been answered
+   */
+  hasAnsweredQuestion(questionId: string): boolean {
+    return this.answeredQuestions.has(questionId);
+  }
+
+  /**
+   * Save answered questions to localStorage
+   */
+  private saveAnsweredQuestionsToStorage(): void {
+    try {
+      const answeredArray = Array.from(this.answeredQuestions.entries());
+      localStorage.setItem(this.ANSWERED_QUESTIONS_KEY, JSON.stringify({
+        questions: answeredArray,
+        timestamp: Date.now()
+      }));
+    } catch (error) {
+      // Error saving answered questions
+    }
+  }
+
+  /**
+   * Restore answered questions from localStorage
+   */
+  private restoreAnsweredQuestions(): void {
+    try {
+      const saved = localStorage.getItem(this.ANSWERED_QUESTIONS_KEY);
+      if (saved) {
+        const parsed = JSON.parse(saved);
+        const twelveHoursAgo = Date.now() - (12 * 60 * 60 * 1000);
+        
+        if (parsed.timestamp && parsed.timestamp > twelveHoursAgo) {
+          this.answeredQuestions = new Map(parsed.questions);
+        } else {
+          this.clearAnsweredQuestionsFromStorage();
+        }
+      }
+    } catch (error) {
+      this.clearAnsweredQuestionsFromStorage();
+    }
+  }
+
+  /**
+   * Clear answered questions from storage
+   */
+  private clearAnsweredQuestionsFromStorage(): void {
+    try {
+      localStorage.removeItem(this.ANSWERED_QUESTIONS_KEY);
+    } catch (error) {
+      // Error clearing answered questions
+    }
   }
 }

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -53,25 +53,31 @@ Object.defineProperty(URL, 'createObjectURL', {
   value: vi.fn(() => 'mock-url'),
 });
 
-// Mock localStorage
+// Mock localStorage with working implementation
+const createStorageMock = () => {
+  let store: { [key: string]: string } = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      store = {};
+    }),
+  };
+};
+
 Object.defineProperty(window, 'localStorage', {
-  value: {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-  },
+  value: createStorageMock(),
   writable: true,
 });
 
 // Mock sessionStorage
 Object.defineProperty(window, 'sessionStorage', {
-  value: {
-    getItem: vi.fn(),
-    setItem: vi.fn(),
-    removeItem: vi.fn(),
-    clear: vi.fn(),
-  },
+  value: createStorageMock(),
   writable: true,
 });
 


### PR DESCRIPTION
## Summary
- Fixed session timeout issue where students lose progress after 20-30 minutes
- Implemented automatic question answer persistence to localStorage
- Extended auth session from 1 hour to 8 hours with activity-based refresh

## Problem
Students were experiencing page reloads and losing their question progress after approximately 20-30 minutes of work. This was due to:
1. Google auth session expiring after 1 hour
2. No persistence mechanism for question answers
3. Radio button selections not persisting visually on reload

## Solution
1. **Extended Auth Sessions**: 
   - Increased session duration to 8 hours (full work/school day)
   - Added activity monitoring to auto-refresh sessions when user is active
   - Sessions now persist across browser refreshes

2. **Question Answer Persistence**:
   - Answers automatically save to localStorage when selected
   - State persists for 12 hours
   - Visual state (radio button selection) now properly restored
   - Clear button removes all saved state

3. **UI Improvements**:
   - Progress tracker now hidden on login page
   - Proper return URL handling on session expiration

## Testing
- Added comprehensive unit tests for TestService persistence
- Fixed localStorage mock in test environment for Vitest compatibility
- All existing tests pass

## Technical Details
- Switched from `browserSessionPersistence` to `browserLocalPersistence`
- Added activity tracking for clicks, typing, and scrolling
- Removed console.error statements for production readiness
- Implemented proper cleanup on component destroy