### PR TITLE
Fix side-nav collapse functionality and add active section styling

### DIFF
--- a/src/app/components/side-nav/side-nav.component.html
+++ b/src/app/components/side-nav/side-nav.component.html
@@ -5,7 +5,9 @@
   <ul class="side-nav--items">
     @for (section of mainSections; track section; let i = $index) {
       <li id="parentList" class="side-nav--items--item">
-        <p class="side-nav--items--item--text" (click)="clickHandlerMainList(i)">{{i + 1}}. {{section}}</p>
+        <p class="side-nav--items--item--text" 
+           [ngClass]="activeSection.mainSectionNumber === i+1? 'side-nav--items--item--text--active':''"
+           (click)="clickHandlerMainList(i)">{{i + 1}}. {{section}}</p>
         <ul class="side-nav--items--item--sublist"
             [ngClass]="isExpanded[i]? 'side-nav--items--item--sublist--expanded': 'side-nav--items--item--sublist--collapsed'">
           @for (subsection of sections[section]; track subsection.name; let j = $index) {

--- a/src/app/components/side-nav/side-nav.component.scss
+++ b/src/app/components/side-nav/side-nav.component.scss
@@ -63,6 +63,12 @@
           color: var(--secondary-color-base);
           cursor: pointer;
         }
+
+        &--active {
+          text-decoration: underline;
+          text-decoration-thickness: 2px;
+          text-underline-offset: 4px;
+        }
       }
 
       &--sublist {

--- a/src/app/components/side-nav/side-nav.component.spec.ts
+++ b/src/app/components/side-nav/side-nav.component.spec.ts
@@ -1,0 +1,304 @@
+import { SideNavComponent } from './side-nav.component';
+import { of, Observable } from 'rxjs';
+import { Question } from '../../models/question.model';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Create a mock service class that implements QuestionsService methods
+class MockQuestionsService {
+  private questionsData: Question[] = [];
+
+  setQuestionsData(questions: Question[]): void {
+    this.questionsData = questions;
+  }
+
+  getQuestions(): Observable<Question[]> {
+    return of(this.questionsData);
+  }
+
+  // Add other methods as stubs if needed
+  getQuestionsBySection(): Observable<Question[]> {
+    return of([]);
+  }
+
+  addQuestion(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  updateQuestion(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  deleteQuestion(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+describe('SideNavComponent', () => {
+  let component: SideNavComponent;
+  let mockQuestionsService: MockQuestionsService;
+
+  const mockQuestions: Question[] = [
+    {
+      id: '1',
+      questionText: 'Test Question 1',
+      mainSection: 'administrativo',
+      subSection: 'subsection 1',
+      subSectionIndex: 0,
+      options: ['A', 'B', 'C', 'D'],
+      correctAnswer: 0,
+      correctAnswerDescription: 'Test'
+    },
+    {
+      id: '2',
+      questionText: 'Test Question 2',
+      mainSection: 'medio ambiente',
+      subSection: 'subsection 2',
+      subSectionIndex: 0,
+      options: ['A', 'B', 'C', 'D'],
+      correctAnswer: 1,
+      correctAnswerDescription: 'Test'
+    }
+  ];
+
+  beforeEach(() => {
+    mockQuestionsService = new MockQuestionsService();
+    mockQuestionsService.setQuestionsData(mockQuestions);
+
+    // Create component instance manually to avoid DI issues
+    component = new SideNavComponent(mockQuestionsService as any);
+    component.activeSection = {
+      mainSection: 'administrativo',
+      subSection: 'subsection 1',
+      mainSectionNumber: 1,
+      subSectionNumber: 1
+    };
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize sections from questions', () => {
+    component.ngOnInit();
+    
+    expect(component.mainSections.length).toBe(2);
+    expect(component.mainSections).toContain('administrativo');
+    expect(component.mainSections).toContain('medio ambiente');
+  });
+
+  it('should expand first section by default', () => {
+    component.ngOnInit();
+    
+    expect(component.isExpanded[0]).toBe(true);
+    expect(component.isExpanded[1]).toBe(false);
+  });
+
+  describe('clickHandlerMainList', () => {
+    beforeEach(() => {
+      component.ngOnInit();
+    });
+
+    it('should toggle expansion state when clicking any section', () => {
+      // First section is expanded by default
+      expect(component.isExpanded[0]).toBe(true);
+      
+      // Click on first section (active section)
+      component.clickHandlerMainList(0);
+      expect(component.isExpanded[0]).toBe(false);
+      
+      // Click again to expand
+      component.clickHandlerMainList(0);
+      expect(component.isExpanded[0]).toBe(true);
+    });
+
+    it('should toggle expansion state for non-active sections', () => {
+      // Second section is not expanded by default
+      expect(component.isExpanded[1]).toBe(false);
+      
+      // Click on second section
+      component.clickHandlerMainList(1);
+      expect(component.isExpanded[1]).toBe(true);
+      
+      // Click again to collapse
+      component.clickHandlerMainList(1);
+      expect(component.isExpanded[1]).toBe(false);
+    });
+  });
+
+  describe('active section styling', () => {
+    it('should identify active main section correctly', () => {
+      component.ngOnInit();
+      
+      // First section should be active (mainSectionNumber = 1)
+      expect(component.activeSection.mainSectionNumber).toBe(1);
+      expect(component.activeSection.mainSection).toBe('administrativo');
+    });
+
+    it('should update active section reference correctly', () => {
+      component.ngOnInit();
+      
+      // Change active section to second main section
+      component.activeSection = {
+        mainSection: 'medio ambiente',
+        subSection: 'subsection 2',
+        mainSectionNumber: 2,
+        subSectionNumber: 1
+      };
+      
+      // Verify the active section has been updated
+      expect(component.activeSection.mainSectionNumber).toBe(2);
+      expect(component.activeSection.mainSection).toBe('medio ambiente');
+    });
+  });
+
+  it('should emit click event when subsection is clicked', () => {
+    const emitSpy = vi.spyOn(component.clickEmit, 'emit');
+    
+    component.clickHandlerSublist('administrativo', 'subsection 1', 1, 1);
+    
+    expect(emitSpy).toHaveBeenCalledWith({
+      mainSection: 'administrativo',
+      subSection: 'subsection 1',
+      mainSectionNumber: 1,
+      subSectionNumber: 1
+    });
+  });
+
+  it('should toggle sidebar open state', () => {
+    const emitSpy = vi.spyOn(component.expandSidebarEmit, 'emit');
+    
+    expect(component.open).toBe(true);
+    
+    component.iconClickHandler();
+    expect(component.open).toBe(false);
+    expect(emitSpy).toHaveBeenCalledWith(false);
+    
+    component.iconClickHandler();
+    expect(component.open).toBe(true);
+    expect(emitSpy).toHaveBeenCalledWith(true);
+  });
+
+  describe('section sorting', () => {
+    it('should sort main sections according to predefined order', () => {
+      component.ngOnInit();
+      
+      // The order should be: administrativo, medio ambiente (based on sectionOrderEnum)
+      expect(component.mainSections[0]).toBe('administrativo');
+      expect(component.mainSections[1]).toBe('medio ambiente');
+    });
+
+    it('should sort subsections by index', () => {
+      const questionsWithMultipleSubsections: Question[] = [
+        {
+          id: '1',
+          questionText: 'Test 1',
+          mainSection: 'administrativo',
+          subSection: 'subsection B',
+          subSectionIndex: 1,
+          options: ['A', 'B', 'C', 'D'],
+          correctAnswer: 0,
+          correctAnswerDescription: 'Test'
+        },
+        {
+          id: '2',
+          questionText: 'Test 2',
+          mainSection: 'administrativo',
+          subSection: 'subsection A',
+          subSectionIndex: 0,
+          options: ['A', 'B', 'C', 'D'],
+          correctAnswer: 0,
+          correctAnswerDescription: 'Test'
+        }
+      ];
+      
+      mockQuestionsService.setQuestionsData(questionsWithMultipleSubsections);
+      
+      component.ngOnInit();
+      
+      // Subsections should be sorted by index
+      expect(component.sections['administrativo'][0].name).toBe('subsection A');
+      expect(component.sections['administrativo'][1].name).toBe('subsection B');
+    });
+  });
+
+  describe('auto-selection behavior', () => {
+    it('should auto-select first subsection when no active section is set', () => {
+      const emitSpy = vi.spyOn(component.clickEmit, 'emit');
+      
+      // Clear active section
+      component.activeSection = {
+        mainSection: '',
+        subSection: '',
+        mainSectionNumber: 0,
+        subSectionNumber: 0
+      };
+      
+      component.ngOnInit();
+      
+      // Should emit selection of first subsection
+      expect(emitSpy).toHaveBeenCalledWith({
+        mainSection: 'administrativo',
+        subSection: 'subsection 1',
+        mainSectionNumber: 1,
+        subSectionNumber: 1
+      });
+    });
+
+    it('should not auto-select when active section is already set', () => {
+      const emitSpy = vi.spyOn(component.clickEmit, 'emit');
+      
+      // Active section is already set in beforeEach
+      component.ngOnInit();
+      
+      // Should not emit any auto-selection
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('filtering invalid questions', () => {
+    it('should filter out questions with missing required fields', () => {
+      const mixedQuestions: Question[] = [
+        ...mockQuestions,
+        {
+          id: '',
+          questionText: 'Invalid - empty id',
+          mainSection: 'test',
+          subSection: 'test',
+          subSectionIndex: 0,
+          options: ['A'],
+          correctAnswer: 0,
+          correctAnswerDescription: 'Test'
+        },
+        {
+          id: '3',
+          questionText: '',
+          mainSection: 'test',
+          subSection: 'test',
+          subSectionIndex: 0,
+          options: ['A'],
+          correctAnswer: 0,
+          correctAnswerDescription: 'Test'
+        }
+      ];
+      
+      mockQuestionsService.setQuestionsData(mixedQuestions);
+      
+      component.ngOnInit();
+      
+      // Should only include valid questions (2 from mockQuestions)
+      expect(component.mainSections.length).toBe(2);
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should unsubscribe from observables on destroy', () => {
+      const destroySpy = vi.spyOn(component['destroy$'], 'next');
+      const completeSpy = vi.spyOn(component['destroy$'], 'complete');
+      
+      component.ngOnDestroy();
+      
+      expect(destroySpy).toHaveBeenCalled();
+      expect(completeSpy).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/components/side-nav/side-nav.component.ts
+++ b/src/app/components/side-nav/side-nav.component.ts
@@ -93,9 +93,7 @@ export class SideNavComponent implements OnInit, OnDestroy {
   }
 
   clickHandlerMainList(index: number) {
-    if (this.activeSection.mainSectionNumber !== index + 1) {
-      this.isExpanded[index] = !this.isExpanded[index];
-    }
+    this.isExpanded[index] = !this.isExpanded[index];
   }
 
   clickHandlerSublist(mainSection: string, subSection: string, mainSectionNumber: number, subSectionNumber: number) {


### PR DESCRIPTION
## Summary
- Fixed bug where the first main section in the side navigation could not be collapsed
- Added visual feedback by underlining active sections (visible even when collapsed)
- Added comprehensive test suite for the side-nav component

## Problem
Users reported that they could not collapse the first main section in the side navigation menu, while all other sections could be collapsed normally. Additionally, there was no visual indication of which section was active when sections were collapsed.

## Solution
1. **Removed the condition** in `clickHandlerMainList()` that prevented toggling the expansion state when clicking on the active section
2. **Added CSS styling** to underline the active main section with a 2px underline and 4px offset
3. **Updated the template** to apply the active class based on `mainSectionNumber`
4. **Created comprehensive tests** covering all component functionality

## Test plan
- [x] Build passes
- [x] All existing tests pass (173 tests)
- [x] New side-nav component tests pass (15 tests)
- [x] Manual testing: All sections can be collapsed/expanded
- [x] Manual testing: Active section shows underline when collapsed
- [x] Manual testing: Active section styling updates when switching sections